### PR TITLE
Fix localStorage parse error handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,16 @@ function addTask() {
 // Function to load tasks from localStorage
 function loadTasks() {
     const taskList = document.getElementById('todo-list');
-    const tasks = JSON.parse(localStorage.getItem('tasks')) || [];
+    let tasks = [];
+
+    try {
+        const stored = localStorage.getItem('tasks');
+        const parsed = stored ? JSON.parse(stored) : [];
+        tasks = Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+        console.error('Failed to parse tasks from localStorage:', e);
+        tasks = [];
+    }
 
     tasks.forEach(task => {
         const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- make `loadTasks` resilient against invalid data in localStorage

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6846b691516c832caf51fe81d62e57ae